### PR TITLE
Add setup script for Stack

### DIFF
--- a/setup_scripts/setup.sh
+++ b/setup_scripts/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Setup script for the Arkham Horror backend using Stack.
+# This follows the instructions in the project README.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Install Stack if it's not already available
+if ! command -v stack >/dev/null 2>&1; then
+  echo "Stack not found, installing..."
+  curl -sSL https://get.haskellstack.org/ | sh
+fi
+
+cd "$REPO_ROOT/backend"
+
+# Download the correct GHC toolchain and build dependencies
+stack setup
+stack build --fast


### PR DESCRIPTION
## Summary
- add `setup_scripts/setup.sh` to automate `stack` setup for the backend

## Testing
- `bash setup_scripts/setup.sh` *(fails: requires installing Stack, network access may be blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684bf9e0744c832d8315539840d2f322