### PR TITLE
Fix forced ability for The Bloodless Man Unleashed

### DIFF
--- a/backend/arkham-api/library/Arkham/Enemy/Cards/TheBloodlessManUnleashed.hs
+++ b/backend/arkham-api/library/Arkham/Enemy/Cards/TheBloodlessManUnleashed.hs
@@ -35,7 +35,9 @@ instance HasAbilities TheBloodlessManUnleashed where
 instance RunMessage TheBloodlessManUnleashed where
   runMessage msg e@(TheBloodlessManUnleashed attrs) = runQueueT $ case msg of
     UseThisAbility iid (isSource attrs -> True) 1 -> do
-      removeCluesFromPlay <- selectOne $ assetControlledBy iid <> AssetWithTrait Guest
-      for_ removeCluesFromPlay \aid -> removeFromGame aid
+      mGuest <- selectOne $ assetControlledBy iid <> AssetWithTrait Guest
+      for_ mGuest \aid -> do
+        dont $ BecomeSpellbound aid
+        removeFromGame aid
       pure e
     _ -> TheBloodlessManUnleashed <$> liftRunMessage msg attrs


### PR DESCRIPTION
## Summary
- prevent The Bloodless Man Unleashed from triggering spellbound agenda when removing Guests

## Testing
- `stack test --flag arkham-horror-backend:library-only --flag arkham-horror-backend:dev` *(fails: `stack` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe037d16c832d862bf63ae15ab5e1