### PR TITLE
Add Midwinter Gala story assets

### DIFF
--- a/backend/arkham-api/arkham-api.cabal
+++ b/backend/arkham-api/arkham-api.cabal
@@ -563,6 +563,9 @@ library
       Arkham.Asset.Assets.PrudenceDouglas
       Arkham.Asset.Assets.SarahVanShaw
       Arkham.Asset.Assets.RaymondLoggins
+      Arkham.Asset.Assets.DeloresGadling
+      Arkham.Asset.Assets.ThomasOlney
+      Arkham.Asset.Assets.ClaireWilson
       Arkham.Asset.Assets.CaldwellPhilipsEnthralledByLegends
       Arkham.Asset.Assets.CarlSanfordLustingForPower
       Arkham.Asset.Assets.ValeriyaAntonovaWantsOutOfHere

--- a/backend/arkham-api/arkham-api.cabal
+++ b/backend/arkham-api/arkham-api.cabal
@@ -554,6 +554,12 @@ library
       Arkham.Asset.Assets.ArchibaldHudson
       Arkham.Asset.Assets.SpecialAgentCallahan
       Arkham.Asset.Assets.HoracioMartinez
+      Arkham.Asset.Assets.DrMyaBadry
+      Arkham.Asset.Assets.LucasTetlow
+      Arkham.Asset.Assets.ElizabethConrad
+      Arkham.Asset.Assets.MirandaKeeper
+      Arkham.Asset.Assets.ArseneRenard
+      Arkham.Asset.Assets.NovaMalone
       Arkham.Asset.Assets.CaldwellPhilipsEnthralledByLegends
       Arkham.Asset.Assets.CarlSanfordLustingForPower
       Arkham.Asset.Assets.ValeriyaAntonovaWantsOutOfHere

--- a/backend/arkham-api/arkham-api.cabal
+++ b/backend/arkham-api/arkham-api.cabal
@@ -3956,6 +3956,8 @@ library
       Arkham.Story.Cards.ThePalaceOfRainbows
       Arkham.Story.Cards.ThePattern
       Arkham.Story.Cards.TheSentry
+      Arkham.Story.Cards.TMGTheFoundationAllied
+      Arkham.Story.Cards.TMGTheFoundationRival
       Arkham.Story.Cards.TheTrialOfKamanThah
       Arkham.Story.Cards.TheTrialOfNasht
       Arkham.Story.Cards.TheWayOut

--- a/backend/arkham-api/arkham-api.cabal
+++ b/backend/arkham-api/arkham-api.cabal
@@ -560,6 +560,9 @@ library
       Arkham.Asset.Assets.MirandaKeeper
       Arkham.Asset.Assets.ArseneRenard
       Arkham.Asset.Assets.NovaMalone
+      Arkham.Asset.Assets.PrudenceDouglas
+      Arkham.Asset.Assets.SarahVanShaw
+      Arkham.Asset.Assets.RaymondLoggins
       Arkham.Asset.Assets.CaldwellPhilipsEnthralledByLegends
       Arkham.Asset.Assets.CarlSanfordLustingForPower
       Arkham.Asset.Assets.ValeriyaAntonovaWantsOutOfHere

--- a/backend/arkham-api/library/Arkham/Asset.hs
+++ b/backend/arkham-api/library/Arkham/Asset.hs
@@ -1376,6 +1376,9 @@ allAssets =
       , SomeAssetCard prudenceDouglasCard
       , SomeAssetCard sarahVanShawCard
       , SomeAssetCard raymondLogginsCard
+      , SomeAssetCard deloresGadlingCard
+      , SomeAssetCard thomasOlneyCard
+      , SomeAssetCard claireWilsonCard
     , -- Misc
       SomeAssetCard courage
     ]

--- a/backend/arkham-api/library/Arkham/Asset.hs
+++ b/backend/arkham-api/library/Arkham/Asset.hs
@@ -1370,6 +1370,12 @@ allAssets =
       , SomeAssetCard drMyaBadryCard
       , SomeAssetCard lucasTetlowCard
       , SomeAssetCard elizabethConradCard
+      , SomeAssetCard mirandaKeeperCard
+      , SomeAssetCard arseneRenardCard
+      , SomeAssetCard novaMaloneCard
+      , SomeAssetCard prudenceDouglasCard
+      , SomeAssetCard sarahVanShawCard
+      , SomeAssetCard raymondLogginsCard
     , -- Misc
       SomeAssetCard courage
     ]

--- a/backend/arkham-api/library/Arkham/Asset.hs
+++ b/backend/arkham-api/library/Arkham/Asset.hs
@@ -1367,6 +1367,9 @@ allAssets =
       SomeAssetCard ruthWestmacottDarkRevelations
     , -- The Midwinter Gala
       SomeAssetCard archibaldHudsonCard
+      , SomeAssetCard drMyaBadryCard
+      , SomeAssetCard lucasTetlowCard
+      , SomeAssetCard elizabethConradCard
     , -- Misc
       SomeAssetCard courage
     ]

--- a/backend/arkham-api/library/Arkham/Asset/Assets/ArseneRenard.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ArseneRenard.hs
@@ -1,0 +1,47 @@
+module Arkham.Asset.Assets.ArseneRenard (
+  arseneRenard,
+  ArseneRenard(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Cards
+import Arkham.Asset.Import.Lifted
+import Arkham.Helpers.Location (withLocationOf)
+import Arkham.Matcher
+
+newtype ArseneRenard = ArseneRenard AssetAttrs
+  deriving anyclass IsAsset
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+arseneRenard :: AssetCard ArseneRenard
+arseneRenard = allyWith ArseneRenard Cards.arseneRenard (1, 3) noSlots
+
+instance HasAbilities ArseneRenard where
+  getAbilities (ArseneRenard a) =
+    [ limitedAbility (GroupLimit PerGame 1)
+        $ controlledAbility a 1 ControlsThis
+        $ FastAbility Free
+    , controlledAbility
+        a
+        2
+        ( TokensOnLocation YouLocation Token.Antiquity (atLeast 1)
+            <> exists (EnemyAt YourLocation <> EnemyExhausted)
+        )
+        $ FastAbility Free
+    ]
+
+instance RunMessage ArseneRenard where
+  runMessage msg a@(ArseneRenard attrs) = runQueueT $ case msg of
+    UseThisAbility _iid (isSource attrs -> True) 1 -> do
+      locations <- select AnyLocation
+      for_ locations \lid -> placeTokens (attrs.ability 1) lid Token.Antiquity 1
+      pure a
+    UseThisAbility iid (isSource attrs -> True) 2 -> do
+      withLocationOf iid \lid -> removeTokens (attrs.ability 2) lid Token.Antiquity 1
+      player <- getPlayer iid
+      chooseOrRunOne player
+        [ Label "Draw 1 card" [drawCards iid (attrs.ability 2) 1]
+        , Label "Gain 2 resources" [gainResources iid (attrs.ability 2) 2]
+        ]
+      pure a
+    _ -> ArseneRenard <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/ClaireWilson.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ClaireWilson.hs
@@ -1,0 +1,30 @@
+module Arkham.Asset.Assets.ClaireWilson (
+  claireWilson,
+  ClaireWilson(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Cards
+import Arkham.Asset.Import.Lifted
+import Arkham.Matcher
+import Arkham.Trait
+
+newtype ClaireWilson = ClaireWilson AssetAttrs
+  deriving anyclass IsAsset
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+claireWilson :: AssetCard ClaireWilson
+claireWilson = allyWith ClaireWilson Cards.claireWilson (2, 2) noSlots
+
+instance HasAbilities ClaireWilson where
+  getAbilities (ClaireWilson a) =
+    [ restrictedAbility a 1 (ControlsThis <> DuringSkillTest (YourSkillTest AnySkillTest))
+        $ ReactionAbility (CommittedCards #after You $ LengthIs $ AtLeast $ Static 1) (exhaust a)
+    ]
+
+instance RunMessage ClaireWilson where
+  runMessage msg a@(ClaireWilson attrs) = runQueueT $ case msg of
+    UseThisAbility iid (isSource attrs -> True) 1 -> do
+      withSkillTest \sid -> skillTestModifier sid (attrs.ability 1) iid (AnySkillValue 1)
+      pure a
+    _ -> ClaireWilson <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/DeloresGadling.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/DeloresGadling.hs
@@ -1,0 +1,31 @@
+module Arkham.Asset.Assets.DeloresGadling (
+  deloresGadling,
+  DeloresGadling(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Cards
+import Arkham.Asset.Import.Lifted
+import Arkham.Matcher
+import Arkham.SkillType
+import Arkham.Trait
+
+newtype DeloresGadling = DeloresGadling AssetAttrs
+  deriving anyclass IsAsset
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+deloresGadling :: AssetCard DeloresGadling
+deloresGadling = allyWith DeloresGadling Cards.deloresGadling (1, 3) noSlots
+
+instance HasModifiersFor DeloresGadling where
+  getModifiersFor (DeloresGadling a) = for_ a.controller \iid -> \case
+    InvestigatorTarget iid' | iid == iid' -> do
+      action <- getSkillTestAction
+      n <- selectCount $ EnemyAt YourLocation <> EnemyWithTrait Humanoid
+      pure $ [SkillModifier #intellect n | n > 0 && action `elem` [Just #investigate, Just Parley]]
+        <> [MayIgnoreAttacksOfOpportunity]
+    _ -> pure mempty
+
+instance RunMessage DeloresGadling where
+  runMessage msg a@(DeloresGadling attrs) = runQueueT $ case msg of
+    _ -> DeloresGadling <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/DrMyaBadry.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/DrMyaBadry.hs
@@ -1,0 +1,33 @@
+module Arkham.Asset.Assets.DrMyaBadry (
+  drMyaBadry,
+  DrMyaBadry(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Cards
+import Arkham.Asset.Import.Lifted
+import Arkham.Matcher
+import Arkham.Projection
+
+newtype DrMyaBadry = DrMyaBadry AssetAttrs
+  deriving anyclass IsAsset
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+drMyaBadry :: AssetCard DrMyaBadry
+drMyaBadry = allyWith DrMyaBadry Cards.drMyaBadry (2, 2) noSlots
+
+instance HasModifiersFor DrMyaBadry where
+  getModifiersFor (DrMyaBadry a) = controllerGets a [HandSize 2]
+
+instance HasAbilities DrMyaBadry where
+  getAbilities (DrMyaBadry a) = [investigateAbility a 1 (exhaust a) ControlsThis]
+
+instance RunMessage DrMyaBadry where
+  runMessage msg a@(DrMyaBadry attrs) = runQueueT $ case msg of
+    UseThisAbility iid (isSource attrs -> True) 1 -> do
+      cardsInHand <- fieldMap InvestigatorHand length iid
+      sid <- getRandom
+      skillTestModifier sid (attrs.ability 1) iid (BaseSkillOf #intellect cardsInHand)
+      investigate sid iid (attrs.ability 1)
+      pure a
+    _ -> DrMyaBadry <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/ElizabethConrad.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ElizabethConrad.hs
@@ -1,0 +1,36 @@
+module Arkham.Asset.Assets.ElizabethConrad (
+  elizabethConrad,
+  ElizabethConrad(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Cards
+import Arkham.Asset.Import.Lifted
+import Arkham.Helpers.Location (getAccessibleLocations)
+import Arkham.Matcher
+
+newtype ElizabethConrad = ElizabethConrad AssetAttrs
+  deriving anyclass IsAsset
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+elizabethConrad :: AssetCard ElizabethConrad
+elizabethConrad = allyWith ElizabethConrad Cards.elizabethConrad (1, 3) noSlots
+
+instance HasAbilities ElizabethConrad where
+  getAbilities (ElizabethConrad a) =
+    [ restricted a 1 ControlsThis
+        $ ReactionAbility
+            (DrawsCards #after You AnyCards AnyValue <> DuringTurn You)
+            (exhaust a)
+    ]
+
+instance RunMessage ElizabethConrad where
+  runMessage msg a@(ElizabethConrad attrs) = runQueueT $ case msg of
+    UseThisAbility iid (isSource attrs -> True) 1 -> do
+      investigators <- select $ colocatedWith iid
+      chooseOne iid $ targetLabels investigators $ \iid' -> do
+        locations <- getAccessibleLocations iid' attrs
+        chooseOne iid' $ targetLabels locations $ \lid ->
+          Move $ move (attrs.ability 1) iid' lid
+      pure a
+    _ -> ElizabethConrad <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/LucasTetlow.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/LucasTetlow.hs
@@ -1,0 +1,55 @@
+module Arkham.Asset.Assets.LucasTetlow (
+  lucasTetlow,
+  LucasTetlow(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Cards
+import Arkham.Asset.Import.Lifted
+import Arkham.Matcher
+import Arkham.Trait
+
+newtype LucasTetlow = LucasTetlow AssetAttrs
+  deriving anyclass IsAsset
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+lucasTetlow :: AssetCard LucasTetlow
+lucasTetlow = allyWith LucasTetlow Cards.lucasTetlow (3, 1) noSlots
+
+instance HasAbilities LucasTetlow where
+  getAbilities (LucasTetlow a) =
+    [ restricted a 1 ControlsThis
+        $ ReactionAbility (DiscoveringLastClue #after Anyone YourLocation) (exhaust a)
+    ]
+
+instance RunMessage LucasTetlow where
+  runMessage msg a@(LucasTetlow attrs) = runQueueT $ case msg of
+    UseThisAbility iid (isSource attrs -> True) 1 -> do
+      search
+        iid
+        (attrs.ability 1)
+        iid
+        [fromTopOfDeck 9]
+        (basic $ #asset <> withTrait Item)
+        (defer attrs IsDraw)
+      pure a
+    SearchFound iid (isTarget attrs -> True) _ (PlayerCard pc : _) -> do
+      push $ InvestigatorDrewPlayerCardFrom iid pc (Just Deck.InvestigatorDeck)
+      when (Relic `member` toTraits pc) $ gainResources iid (attrs.ability 1) 2
+      when (Tome `member` toTraits pc) $ do
+        windows' <- defaultWindows iid
+        player <- getPlayer iid
+        chooseOne player
+          [ Label "Play it" [PayCardCost iid pc windows']
+          , Label "Do not play" []
+          ]
+      when (Tool `member` toTraits pc) $ do
+        locations <- select $ ConnectedLocation <> LocationWithAnyClues
+        chooseOne iid $ targetLabels locations \lid ->
+          discoverClues iid lid (attrs.ability 1) 1
+      push $ ShuffleDeck iid InvestigatorDeck
+      pure a
+    SearchFound _ (isTarget attrs -> True) _ _ -> do
+      push $ ShuffleDeck (toController attrs) InvestigatorDeck
+      pure a
+    _ -> LucasTetlow <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/MirandaKeeper.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/MirandaKeeper.hs
@@ -1,0 +1,43 @@
+module Arkham.Asset.Assets.MirandaKeeper (
+  mirandaKeeper,
+  MirandaKeeper(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Cards
+import Arkham.Asset.Import.Lifted
+import Arkham.Effect.Window
+import Arkham.Helpers.Location (withLocationOf)
+import Arkham.Matcher
+
+newtype MirandaKeeper = MirandaKeeper AssetAttrs
+  deriving anyclass IsAsset
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+mirandaKeeper :: AssetCard MirandaKeeper
+mirandaKeeper = allyWith MirandaKeeper Cards.mirandaKeeper (2, 2) noSlots
+
+instance HasAbilities MirandaKeeper where
+  getAbilities (MirandaKeeper a) =
+    [ controlledAbility a 1 ControlsThis $ FastAbility (assetUseCost a Supply 1)
+    , restrictedAbility
+        a
+        2
+        (ControlsThis <> TokensOnLocation YouLocation Token.Antiquity (atLeast 1))
+        $ ReactionAbility
+          (SkillTestResult #after You AnySkillTest (SuccessResult $ atLeast 2))
+          Free
+    ]
+
+instance RunMessage MirandaKeeper where
+  runMessage msg a@(MirandaKeeper attrs) = runQueueT $ case msg of
+    UseThisAbility iid (isSource attrs -> True) 1 -> do
+      withLocationOf iid \lid -> placeTokens (attrs.ability 1) lid Token.Antiquity 1
+      ems <- effectModifiers (attrs.ability 1) [AnySkillValue 2]
+      push $ CreateWindowModifierEffect (FirstEffectWindow [EffectNextSkillTestWindow iid, EffectRoundWindow]) ems (attrs.ability 1) (toTarget iid)
+      pure a
+    UseThisAbility iid (isSource attrs -> True) 2 -> do
+      withLocationOf iid \lid -> removeTokens (attrs.ability 2) lid Token.Antiquity 1
+      gainResources iid (attrs.ability 2) 2
+      pure a
+    _ -> MirandaKeeper <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/NovaMalone.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/NovaMalone.hs
@@ -1,0 +1,37 @@
+module Arkham.Asset.Assets.NovaMalone (
+  novaMalone,
+  NovaMalone(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Cards
+import Arkham.Asset.Import.Lifted
+import Arkham.Matcher
+
+newtype NovaMalone = NovaMalone AssetAttrs
+  deriving anyclass IsAsset
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+novaMalone :: AssetCard NovaMalone
+novaMalone = allyWith NovaMalone Cards.novaMalone (3, 1) noSlots
+
+instance HasAbilities NovaMalone where
+  getAbilities (NovaMalone a) =
+    [ fightAbility a 1 (exhaust a) ControlsThis
+    , limitedAbility (PlayerLimit PerRound 1)
+        $ reaction a 2 ControlsThis Free (EnemyDefeated #after You ByAny AnyEnemy)
+    ]
+
+instance RunMessage NovaMalone where
+  runMessage msg a@(NovaMalone attrs) = runQueueT $ case msg of
+    UseThisAbility iid (isSource attrs -> True) 1 -> do
+      resources <- field InvestigatorResources iid
+      let base = min 7 resources
+      sid <- getRandom
+      skillTestModifiers sid (attrs.ability 1) iid [BaseSkillOf #combat base, DamageDealt 1]
+      chooseFightEnemy sid iid (attrs.ability 1)
+      pure a
+    UseThisAbility iid (isSource attrs -> True) 2 -> do
+      gainResources iid (attrs.ability 2) 1
+      pure a
+    _ -> NovaMalone <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/PrudenceDouglas.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/PrudenceDouglas.hs
@@ -1,0 +1,44 @@
+module Arkham.Asset.Assets.PrudenceDouglas (
+  prudenceDouglas,
+  PrudenceDouglas(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Cards
+import Arkham.Asset.Import.Lifted
+import Arkham.Helpers.Window (cardDrawn)
+import Arkham.Matcher
+import Arkham.Strategy
+
+newtype PrudenceDouglas = PrudenceDouglas AssetAttrs
+  deriving anyclass IsAsset
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+prudenceDouglas :: AssetCard PrudenceDouglas
+prudenceDouglas = allyWith PrudenceDouglas Cards.prudenceDouglas (2, 2) noSlots
+
+instance HasAbilities PrudenceDouglas where
+  getAbilities (PrudenceDouglas a) =
+    [ controlledAbility a 1 (DuringTurn You)
+        $ FastAbility (exhaust a <> assetUseCost a Portent 1)
+    ]
+
+instance RunMessage PrudenceDouglas where
+  runMessage msg a@(PrudenceDouglas attrs) = runQueueT $ case msg of
+    UseThisAbility iid (isSource attrs -> True) 1 -> do
+      lookAt
+        iid
+        (attrs.ability 1)
+        EncounterDeckTarget
+        [(fromTopOfDeck 4, PutBackInAnyOrder)]
+        #any
+        (defer attrs IsNotDraw)
+      pure a
+    SearchFound iid (isTarget attrs -> True) Deck.EncounterDeck cards -> do
+      let encounterCards = onlyEncounterCards cards
+          discardable = filter (notElem Elite . toTraits) encounterCards
+      focusCards encounterCards do
+        chooseUpToNM iid 2 "Done discarding" do
+          targets discardable $ \c -> push $ AddToEncounterDiscard c
+      pure a
+    _ -> PrudenceDouglas <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/RaymondLoggins.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/RaymondLoggins.hs
@@ -1,0 +1,35 @@
+module Arkham.Asset.Assets.RaymondLoggins (
+  raymondLoggins,
+  RaymondLoggins(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Cards
+import Arkham.Asset.Import.Lifted
+import Arkham.Helpers.Window (cardDrawn)
+import Arkham.Matcher
+
+newtype RaymondLoggins = RaymondLoggins AssetAttrs
+  deriving anyclass IsAsset
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+raymondLoggins :: AssetCard RaymondLoggins
+raymondLoggins = allyWith RaymondLoggins Cards.raymondLoggins (1, 2) noSlots
+
+instance HasAbilities RaymondLoggins where
+  getAbilities (RaymondLoggins a) =
+    [ reactionAbility
+        a
+        1
+        (assetUseCost a Truth 1)
+        (DrawCard #when You (basic NonWeaknessTreachery) EncounterDeck)
+        ControlsThis
+    ]
+
+instance RunMessage RaymondLoggins where
+  runMessage msg a@(RaymondLoggins attrs) = runQueueT $ case msg of
+    UseCardAbility iid (isSource attrs -> True) 1 (cardDrawn -> card) _ -> do
+      cancelRevelation attrs card
+      assignHorror iid attrs 1
+      pure a
+    _ -> RaymondLoggins <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/SarahVanShaw.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/SarahVanShaw.hs
@@ -1,0 +1,36 @@
+module Arkham.Asset.Assets.SarahVanShaw (
+  sarahVanShaw,
+  SarahVanShaw(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Cards
+import Arkham.Asset.Import.Lifted
+import Arkham.Matcher
+
+newtype SarahVanShaw = SarahVanShaw AssetAttrs
+  deriving anyclass IsAsset
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+sarahVanShaw :: AssetCard SarahVanShaw
+sarahVanShaw = allyWith SarahVanShaw Cards.sarahVanShaw (3, 1) noSlots
+
+resourcesPaid :: Payment -> Int
+resourcesPaid (ResourcePayment n) = n
+resourcesPaid (Payments ps) = sum $ map resourcesPaid ps
+resourcesPaid _ = 0
+
+instance HasAbilities SarahVanShaw where
+  getAbilities (SarahVanShaw a) =
+    [ withAdditionalCost (UpTo (Fixed 2) $ ResourceCost 1)
+        $ fightAbility a 1 (exhaust a) ControlsThis
+    ]
+
+instance RunMessage SarahVanShaw where
+  runMessage msg a@(SarahVanShaw attrs) = runQueueT $ case msg of
+    UseCardAbility iid (isSource attrs -> True) 1 _ (resourcesPaid -> n) -> do
+      sid <- getRandom
+      skillTestModifiers sid (attrs.ability 1) iid [AddSkillValue #willpower, DamageDealt n]
+      chooseFightEnemy sid iid (attrs.ability 1)
+      pure a
+    _ -> SarahVanShaw <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/ThomasOlney.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ThomasOlney.hs
@@ -1,0 +1,57 @@
+module Arkham.Asset.Assets.ThomasOlney (
+  thomasOlney,
+  ThomasOlney(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Cards
+import Arkham.Asset.Import.Lifted
+import Arkham.Matcher
+import Arkham.Trait
+import Arkham.Message.Lifted.Choose
+import Arkham.Message.Lifted (commitCard, discardTopOfDeckAndHandle)
+import Data.Text (unpack)
+import Text.Read (readMaybe)
+
+newtype Meta = Meta { chosenTrait :: Maybe Trait }
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+newtype ThomasOlney = ThomasOlney (With AssetAttrs Meta)
+  deriving anyclass IsAsset
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+thomasOlney :: AssetCard ThomasOlney
+thomasOlney = ally (ThomasOlney . (`with` Meta Nothing)) Cards.thomasOlney (3, 1)
+
+instance HasAbilities ThomasOlney where
+  getAbilities (ThomasOlney (With a _)) =
+    [ controlledAbility a 1 ControlsThis $ FastAbility (exhaust a)
+    , restrictedAbility a 2 (ControlsThis <> DuringSkillTest SkillTestAtYourLocation) $ FastAbility (exhaust a)
+    ]
+
+instance RunMessage ThomasOlney where
+  runMessage msg a@(ThomasOlney (With attrs meta)) = runQueueT $ case msg of
+    UseThisAbility iid (isSource attrs -> True) 1 -> do
+      chooseOneDropDown iid
+        [ (tshow trait, HandleTargetChoice iid (attrs.ability 1) (LabeledTarget (tshow trait) (toTarget attrs)))
+        | trait <- [minBound ..]
+        ]
+      pure a
+    HandleTargetChoice iid (isAbilitySource attrs 1 -> True) (LabeledTarget t (isTarget attrs -> True)) -> do
+      case readMaybe (unpack t) of
+        Just trait -> do
+          push $ DiscardTopOfEncounterDeck iid 1 (attrs.ability 1) (Just $ toTarget attrs)
+          pure $ ThomasOlney $ With attrs (meta {chosenTrait = Just trait})
+        Nothing -> pure a
+    DiscardedTopOfEncounterDeck iid cards _ (isTarget attrs -> True) -> do
+      for_ meta.chosenTrait \trait -> do
+        when (any (`cardMatch` CardWithTrait trait) cards) $ gainResources iid (attrs.ability 1) 2
+      pure $ ThomasOlney $ With attrs (meta {chosenTrait = Nothing})
+    UseThisAbility iid (isSource attrs -> True) 2 -> do
+      discardTopOfDeckAndHandle iid (attrs.ability 2) 1 attrs
+      pure a
+    DiscardedTopOfDeck iid (card : _) _ (isTarget attrs -> True) -> do
+      withSkillTest \_ -> commitCard iid (PlayerCard card)
+      pure a
+    _ -> ThomasOlney . (`with` meta) <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Cards.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Cards.hs
@@ -74,6 +74,12 @@ allPlayerAssetCards =
       , archibaldHudsonCard
       , specialAgentCallahanCard
       , horacioMartinezCard
+      , drMyaBadryCard
+      , lucasTetlowCard
+      , elizabethConradCard
+      , mirandaKeeperCard
+      , arseneRenardCard
+      , novaMaloneCard
       , caldwellPhilipsEnthralledByLegendsCard
       , carlSanfordLustingForPowerCard
       , valeriyaAntonovaWantsOutOfHereCard

--- a/backend/arkham-api/library/Arkham/Asset/Cards.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Cards.hs
@@ -80,6 +80,9 @@ allPlayerAssetCards =
       , mirandaKeeperCard
       , arseneRenardCard
       , novaMaloneCard
+      , prudenceDouglasCard
+      , sarahVanShawCard
+      , raymondLogginsCard
       , caldwellPhilipsEnthralledByLegendsCard
       , carlSanfordLustingForPowerCard
       , valeriyaAntonovaWantsOutOfHereCard

--- a/backend/arkham-api/library/Arkham/Asset/Cards.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Cards.hs
@@ -83,6 +83,9 @@ allPlayerAssetCards =
       , prudenceDouglasCard
       , sarahVanShawCard
       , raymondLogginsCard
+      , deloresGadlingCard
+      , thomasOlneyCard
+      , claireWilsonCard
       , caldwellPhilipsEnthralledByLegendsCard
       , carlSanfordLustingForPowerCard
       , valeriyaAntonovaWantsOutOfHereCard

--- a/backend/arkham-api/library/Arkham/Asset/Cards/Standalone.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Cards/Standalone.hs
@@ -307,6 +307,41 @@ novaMaloneCard =
     , cdSanity = Just 1
     }
 
+prudenceDouglasCard :: CardDef
+prudenceDouglasCard =
+  (storyAsset "71029" ("Prudence Douglas" <:> "Pragmatic Occultist") 2 TheMidwinterGala)
+    { cdCardTraits = setFromList [Ally, Guest, Sorcerer, SilverTwilight]
+    , cdSkills = [#willpower, #willpower, #agility, #agility]
+    , cdSlots = [#ally]
+    , cdUnique = True
+    , cdUses = uses Portent 3
+    , cdHealth = Just 2
+    , cdSanity = Just 2
+    }
+
+sarahVanShawCard :: CardDef
+sarahVanShawCard =
+  (storyAsset "71030" ("Sarah Van Shaw" <:> "Lodge Warden") 2 TheMidwinterGala)
+    { cdCardTraits = setFromList [Ally, Guest, SilverTwilight]
+    , cdSkills = [#combat, #combat, #agility, #agility]
+    , cdSlots = [#ally]
+    , cdUnique = True
+    , cdHealth = Just 3
+    , cdSanity = Just 1
+    }
+
+raymondLogginsCard :: CardDef
+raymondLogginsCard =
+  (storyAsset "71031" ("Raymond Loggins" <:> "Mysterious Benefactor") 3 TheMidwinterGala)
+    { cdCardTraits = setFromList [Ally, Guest, Sorcerer, SilverTwilight]
+    , cdSkills = [#willpower, #willpower, #intellect, #intellect]
+    , cdSlots = [#ally]
+    , cdUnique = True
+    , cdUses = uses Truth 4
+    , cdHealth = Just 1
+    , cdSanity = Just 2
+    }
+
 caldwellPhilipsEnthralledByLegendsCard :: CardDef
 caldwellPhilipsEnthralledByLegendsCard =
   (storyAsset "71063b" ("Caldwell Philips" <:> "Enthralled by Legends") 0 TheMidwinterGala)

--- a/backend/arkham-api/library/Arkham/Asset/Cards/Standalone.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Cards/Standalone.hs
@@ -240,6 +240,73 @@ horacioMartinezCard =
     , cdSanity = Just 1
     }
 
+drMyaBadryCard :: CardDef
+drMyaBadryCard =
+  (storyAsset "71023" ("Dr. Mya Badry" <:> "Medical Examiner") 2 TheMidwinterGala)
+    { cdCardTraits = setFromList [Ally, Guest, Miskatonic]
+    , cdSkills = [#intellect, #intellect, #agility, #agility]
+    , cdSlots = [#ally]
+    , cdUnique = True
+    , cdHealth = Just 2
+    , cdSanity = Just 2
+    }
+
+lucasTetlowCard :: CardDef
+lucasTetlowCard =
+  (storyAsset "71024" ("Lucas Tetlow" <:> "Faculty Curator") 2 TheMidwinterGala)
+    { cdCardTraits = setFromList [Ally, Guest, Miskatonic]
+    , cdSkills = [#intellect, #intellect, #combat, #combat]
+    , cdSlots = [#ally]
+    , cdUnique = True
+    , cdHealth = Just 3
+    , cdSanity = Just 1
+    }
+
+elizabethConradCard :: CardDef
+elizabethConradCard =
+  (storyAsset "71025" ("Elizabeth Conrad" <:> "Completely Zozzled") 3 TheMidwinterGala)
+    { cdCardTraits = setFromList [Ally, Guest, Miskatonic]
+    , cdSkills = [#willpower, #willpower, #agility, #agility]
+    , cdSlots = [#ally]
+    , cdUnique = True
+    , cdHealth = Just 1
+    , cdSanity = Just 3
+    }
+
+mirandaKeeperCard :: CardDef
+mirandaKeeperCard =
+  (storyAsset "71026" ("Miranda Keeper" <:> "Antiquities \"Trader\"") 2 TheMidwinterGala)
+    { cdCardTraits = setFromList [Ally, Guest, Syndicate]
+    , cdSkills = [#intellect, #intellect, #combat, #combat]
+    , cdSlots = [#ally]
+    , cdUnique = True
+    , cdUses = uses Supply 3
+    , cdHealth = Just 2
+    , cdSanity = Just 2
+    }
+
+arseneRenardCard :: CardDef
+arseneRenardCard =
+  (storyAsset "71027" ("Ars\xE8ne Renard" <:> "Gentleman Thief") 2 TheMidwinterGala)
+    { cdCardTraits = setFromList [Ally, Guest, Syndicate]
+    , cdSkills = [#intellect, #intellect, #agility, #agility]
+    , cdSlots = [#ally]
+    , cdUnique = True
+    , cdHealth = Just 1
+    , cdSanity = Just 3
+    }
+
+novaMaloneCard :: CardDef
+novaMaloneCard =
+  (storyAsset "71028" ("Nova Malone" <:> "Commanding Gangster") 3 TheMidwinterGala)
+    { cdCardTraits = setFromList [Ally, Guest, Syndicate]
+    , cdSkills = [#willpower, #willpower, #combat, #combat]
+    , cdSlots = [#ally]
+    , cdUnique = True
+    , cdHealth = Just 3
+    , cdSanity = Just 1
+    }
+
 caldwellPhilipsEnthralledByLegendsCard :: CardDef
 caldwellPhilipsEnthralledByLegendsCard =
   (storyAsset "71063b" ("Caldwell Philips" <:> "Enthralled by Legends") 0 TheMidwinterGala)

--- a/backend/arkham-api/library/Arkham/Asset/Cards/Standalone.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Cards/Standalone.hs
@@ -342,6 +342,39 @@ raymondLogginsCard =
     , cdSanity = Just 2
     }
 
+deloresGadlingCard :: CardDef
+deloresGadlingCard =
+  (storyAsset "71041" ("Delores Gadling" <:> "Lantern Club Infiltrator") 2 TheMidwinterGala)
+    { cdCardTraits = setFromList [Ally, Guest, Kingsport]
+    , cdSkills = [#combat, #combat, #agility, #agility]
+    , cdSlots = [#ally]
+    , cdUnique = True
+    , cdHealth = Just 1
+    , cdSanity = Just 3
+    }
+
+thomasOlneyCard :: CardDef
+thomasOlneyCard =
+  (storyAsset "71042" ("Thomas Olney" <:> "Inquisitive Adventurer") 2 TheMidwinterGala)
+    { cdCardTraits = setFromList [Ally, Guest, Wayfarer]
+    , cdSkills = [#willpower, #willpower, #intellect, #intellect]
+    , cdSlots = [#ally]
+    , cdUnique = True
+    , cdHealth = Just 3
+    , cdSanity = Just 1
+    }
+
+claireWilsonCard :: CardDef
+claireWilsonCard =
+  (storyAsset "71043" ("Claire Wilson" <:> "Entirely Unimpressed") 2 TheMidwinterGala)
+    { cdCardTraits = setFromList [Ally, Guest, Kingsport]
+    , cdSkills = [#willpower, #willpower, #agility, #agility]
+    , cdSlots = [#ally]
+    , cdUnique = True
+    , cdHealth = Just 2
+    , cdSanity = Just 2
+    }
+
 caldwellPhilipsEnthralledByLegendsCard :: CardDef
 caldwellPhilipsEnthralledByLegendsCard =
   (storyAsset "71063b" ("Caldwell Philips" <:> "Enthralled by Legends") 0 TheMidwinterGala)

--- a/backend/arkham-api/library/Arkham/Story/Cards.hs
+++ b/backend/arkham-api/library/Arkham/Story/Cards.hs
@@ -142,6 +142,8 @@ allStoryCards =
       , returnToSickeningReality_23
       , returnToSickeningReality_24
       , realityAcid
+      , tmgTheFoundationAllied
+      , tmgTheFoundationRival
       ]
 
 victory :: Int -> CardDef -> CardDef
@@ -494,3 +496,11 @@ realityAcid =
     { cdEncounterSet = Nothing
     , cdEncounterSetQuantity = Nothing
     }
+
+tmgTheFoundationAllied :: CardDef
+tmgTheFoundationAllied =
+  doubleSided "71015b" $ story "71015" "The Foundation [guardian]" TheMidwinterGala
+
+tmgTheFoundationRival :: CardDef
+tmgTheFoundationRival =
+  doubleSided "71015" $ story "71015b" "The Foundation [guardian]" TheMidwinterGala

--- a/backend/arkham-api/library/Arkham/Story/Cards/TMGTheFoundationAllied.hs
+++ b/backend/arkham-api/library/Arkham/Story/Cards/TMGTheFoundationAllied.hs
@@ -1,0 +1,59 @@
+module Arkham.Story.Cards.TMGTheFoundationAllied (
+  tmgTheFoundationAllied,
+  TMGTheFoundationAllied(..),
+) where
+
+import Arkham.Ability
+import Arkham.Asset.Cards qualified as Assets
+import Arkham.Enemy.Cards qualified as Enemies
+import Arkham.Matcher
+import Arkham.Message.Lifted
+import Arkham.Story.Cards qualified as Cards
+import Arkham.Story.Import.Lifted
+
+newtype TMGTheFoundationAllied = TMGTheFoundationAllied StoryAttrs
+  deriving anyclass (IsStory, HasModifiersFor, HasAbilities)
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+-- | 'The Foundation [guardian]' allied story card (#71015).
+-- This side represents working with The Foundation.
+tmgTheFoundationAllied :: StoryCard TMGTheFoundationAllied
+tmgTheFoundationAllied = story TMGTheFoundationAllied Cards.tmgTheFoundationAllied
+
+instance HasAbilities TMGTheFoundationAllied where
+  getAbilities (TMGTheFoundationAllied attrs) =
+    [ mkAbility attrs 1
+        $ forced
+        $ EnemyDefeated #when Anyone ByAny (enemyIs Enemies.theBloodlessManUnleashed)
+    , restrictedAbility attrs 2
+        ( Here
+            <> exists (assetIs Assets.jewelOfSarnath <> assetAtLocationWith You)
+            <> notExists (enemyIs Enemies.theBloodlessMan)
+            <> notExists (enemyIs Enemies.theBloodlessManUnleashed)
+        )
+        actionAbility
+    , restrictedAbility attrs 3
+        (exists $ assetIs Assets.jewelOfSarnath <> AssetControlledBy Anyone)
+        $ Objective
+        $ triggered (RoundEnds #when) (GroupClueCost (PerPlayer 2) Anywhere)
+    ]
+
+instance RunMessage TMGTheFoundationAllied where
+  runMessage msg s@(TMGTheFoundationAllied attrs) = runQueueT $ case msg of
+    UseCardAbility _ (isSource attrs -> True) 1 (defeatedEnemy -> enemy) _ -> do
+      mAid <- selectOne $ assetIs Assets.jewelOfSarnath <> AssetAttachedTo (EnemyWithId enemy)
+      for_ mAid \aid -> do
+        mLoc <- field EnemyLocation enemy
+        for_ mLoc \lid -> push $ AttachAsset aid (LocationTarget lid)
+      pure s
+    UseCardAbility iid (isSource attrs -> True) 2 _ _ -> do
+      aid <- selectJust $ assetIs Assets.jewelOfSarnath <> assetAtLocationWith iid
+      pushAll
+        [ TakeControlOfAsset iid aid
+        , PlaceDamage (attrs.ability 2) (AssetTarget aid) 1
+        ]
+      pure s
+    UseCardAbility _ (isSource attrs -> True) 3 _ _ -> do
+      advancedWithClues attrs
+      pure s
+    _ -> TMGTheFoundationAllied <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Story/Cards/TMGTheFoundationRival.hs
+++ b/backend/arkham-api/library/Arkham/Story/Cards/TMGTheFoundationRival.hs
@@ -1,0 +1,60 @@
+module Arkham.Story.Cards.TMGTheFoundationRival (
+  tmgTheFoundationRival,
+  TMGTheFoundationRival(..),
+) where
+
+import Arkham.Ability
+import Arkham.Deck qualified as Deck
+import Arkham.Enemy.Cards qualified as Enemies
+import Arkham.Helpers.Query
+import Arkham.Matcher
+import Arkham.Message.Lifted
+import Arkham.Story.Cards qualified as Cards
+import Arkham.Story.Import.Lifted
+
+newtype TMGTheFoundationRival = TMGTheFoundationRival StoryAttrs
+  deriving anyclass (IsStory, HasModifiersFor, HasAbilities)
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+-- | 'The Foundation [guardian]' rival story card (#71015b).
+-- Represents conflict with The Foundation.
+tmgTheFoundationRival :: StoryCard TMGTheFoundationRival
+tmgTheFoundationRival = story TMGTheFoundationRival Cards.tmgTheFoundationRival
+
+instance HasAbilities TMGTheFoundationRival where
+  getAbilities (TMGTheFoundationRival attrs) =
+    [ restrictedAbility attrs 1
+        (exists $ enemyIs Enemies.valeriyaAntonovaDontMessWithHer <> enemyAtLocationWith You)
+        parleyAction_
+    , mkAbility attrs 2
+        $ forced
+        $ CluesOnThis (AtLeast $ StaticWithPerPlayer 1 1)
+    ]
+
+instance RunMessage TMGTheFoundationRival where
+  runMessage msg s@(TMGTheFoundationRival attrs) = runQueueT $ case msg of
+    ResolveStory _ ResolveIt story' | story' == toId attrs -> do
+      rookie <- getSetAsideCardsMatching $ cardIs Enemies.rookieCop
+      pushAll [ShuffleCardsIntoDeck Deck.EncounterDeck rookie]
+      valeriya <- getSetAsideCardsMatching $ cardIs Enemies.valeriyaAntonovaDontMessWithHer
+      withLeadInvestigator \lid ->
+        for_ valeriya \card -> withLocationOf lid (createEnemyAt_ card)
+      pure s
+    UseCardAbility iid (isSource attrs -> True) 1 _ _ -> do
+      enemy <- selectJust $ enemyIs Enemies.valeriyaAntonovaDontMessWithHer <> enemyAtLocationWith iid
+      sid <- getRandom
+      parley sid iid (attrs.ability 1) enemy #combat (Fixed 3)
+      pure s
+    PassedThisSkillTest _ (isAbilitySource attrs 1 -> True) -> do
+      placeClues (attrs.ability 1) attrs 1
+      pure s
+    UseCardAbility _ (isSource attrs -> True) 2 _ _ -> do
+      valeriya <- selectJust $ enemyIs Enemies.valeriyaAntonovaDontMessWithHer
+      pushAll
+        [ AddToVictory (toTarget attrs)
+        , AddToVictory (EnemyTarget valeriya)
+        , RemoveAllCopiesOfEncounterCardFromGame (cardIs Enemies.rookieCop)
+        ]
+      removeStory attrs
+      pure s
+    _ -> TMGTheFoundationRival <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Token.hs
+++ b/backend/arkham-api/library/Arkham/Token.hs
@@ -11,6 +11,7 @@ data Token
   | AlarmLevel
   | Ammo
   | Antiquity
+  | Portent
   | Bounty
   | Charge
   | Clue
@@ -41,6 +42,7 @@ data Token
   | Warning
   | Wish
   | Whistle
+  | Truth
   deriving stock (Show, Eq, Ord, Generic, Data)
   deriving anyclass (ToJSON, FromJSON, ToJSONKey, FromJSONKey)
 
@@ -82,8 +84,14 @@ instance IsLabel "doom" Token where
 instance IsLabel "antiquity" Token where
   fromLabel = Antiquity
 
+instance IsLabel "portent" Token where
+  fromLabel = Portent
+
 instance IsLabel "warning" Token where
   fromLabel = Warning
+
+instance IsLabel "truth" Token where
+  fromLabel = Truth
 
 type Tokens = Map Token Int
 

--- a/backend/arkham-api/library/Arkham/Token.hs
+++ b/backend/arkham-api/library/Arkham/Token.hs
@@ -10,6 +10,7 @@ data Token
   = Aether
   | AlarmLevel
   | Ammo
+  | Antiquity
   | Bounty
   | Charge
   | Clue
@@ -77,6 +78,9 @@ instance IsLabel "clue" Token where
 
 instance IsLabel "doom" Token where
   fromLabel = Doom
+
+instance IsLabel "antiquity" Token where
+  fromLabel = Antiquity
 
 instance IsLabel "warning" Token where
   fromLabel = Warning

--- a/frontend/src/arkham/types/Token.ts
+++ b/frontend/src/arkham/types/Token.ts
@@ -4,6 +4,7 @@ export type Token
   = 'Aether'
   | 'AlarmLevel'
   | 'Ammo'
+  | 'Antiquity'
   | 'Bounty'
   | 'Charge'
   | 'Clue'
@@ -39,6 +40,7 @@ export const TokenType = {
   Aether: 'Aether',
   AlarmLevel: 'AlarmLevel',
   Ammo: 'Ammo',
+  Antiquity: 'Antiquity',
   Bounty: 'Bounty',
   Charge: 'Charge',
   Clue: 'Clue',
@@ -75,6 +77,7 @@ export const tokenDecoder: JsonDecoder.Decoder<Token> = JsonDecoder.oneOf<Token>
   JsonDecoder.literal('Aether'),
   JsonDecoder.literal('AlarmLevel'),
   JsonDecoder.literal('Ammo'),
+  JsonDecoder.literal('Antiquity'),
   JsonDecoder.literal('Bounty'),
   JsonDecoder.literal('Charge'),
   JsonDecoder.literal('Clue'),

--- a/frontend/src/arkham/types/Token.ts
+++ b/frontend/src/arkham/types/Token.ts
@@ -5,6 +5,7 @@ export type Token
   | 'AlarmLevel'
   | 'Ammo'
   | 'Antiquity'
+  | 'Portent'
   | 'Bounty'
   | 'Charge'
   | 'Clue'
@@ -35,12 +36,14 @@ export type Token
   | 'Warning'
   | 'Whistle'
   | 'Wish'
+  | 'Truth'
 
 export const TokenType = {
   Aether: 'Aether',
   AlarmLevel: 'AlarmLevel',
   Ammo: 'Ammo',
   Antiquity: 'Antiquity',
+  Portent: 'Portent',
   Bounty: 'Bounty',
   Charge: 'Charge',
   Clue: 'Clue',
@@ -71,6 +74,7 @@ export const TokenType = {
   Warning: 'Warning',
   Whistle: 'Whistle',
   Wish: 'Wish',
+  Truth: 'Truth',
 } as const;
 
 export const tokenDecoder: JsonDecoder.Decoder<Token> = JsonDecoder.oneOf<Token>([
@@ -78,6 +82,7 @@ export const tokenDecoder: JsonDecoder.Decoder<Token> = JsonDecoder.oneOf<Token>
   JsonDecoder.literal('AlarmLevel'),
   JsonDecoder.literal('Ammo'),
   JsonDecoder.literal('Antiquity'),
+  JsonDecoder.literal('Portent'),
   JsonDecoder.literal('Bounty'),
   JsonDecoder.literal('Charge'),
   JsonDecoder.literal('Clue'),
@@ -108,6 +113,7 @@ export const tokenDecoder: JsonDecoder.Decoder<Token> = JsonDecoder.oneOf<Token>
   JsonDecoder.literal('Warning'),
   JsonDecoder.literal('Whistle'),
   JsonDecoder.literal('Wish'),
+  JsonDecoder.literal('Truth'),
 ], 'Token');
 
 export type Tokens = Partial<Record<Token, number>>;


### PR DESCRIPTION
## Summary
- add Miranda Keeper, Arsène Renard and Nova Malone asset modules
- expose new story assets in card catalog and cabal file
- register Antiquity token type

## Testing
- `make -C backend validate` *(fails: `stack` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fea99d470832db254c66db38fc41e