### PR TITLE
Finish Midwinter Gala skeleton

### DIFF
--- a/backend/arkham-api/library/Arkham/CampaignLogKey.hs
+++ b/backend/arkham-api/library/Arkham/CampaignLogKey.hs
@@ -47,6 +47,9 @@ data CampaignLogKey
   | TheInvestigatorsFledTheSceneOfTheCrime
   | TheExcelsiorIsQuietForNow
   | TheMurdersContinueUnsolved
+  | -- | The Midwinter Gala
+    TheInvestigatorsSurvivedTheMidwinterGala
+  | TheInvestigatorsWereDefeatedAtTheMidwinterGala
   | -- | Player Cards
     YouHaveIdentifiedTheSolution
   | YouHaveTranslatedTheGlyphs
@@ -95,6 +98,8 @@ parseStringKey = withText "CampaignLogKey" $ \case
   "TheInvestigatorsFledTheSceneOfTheCrime" -> pure TheInvestigatorsFledTheSceneOfTheCrime
   "TheExcelsiorClaimsAnotherVictim" -> pure TheExcelsiorClaimsAnotherVictim
   "TheMurdersContinueUnsolved" -> pure TheMurdersContinueUnsolved
+  "TheInvestigatorsSurvivedTheMidwinterGala" -> pure TheInvestigatorsSurvivedTheMidwinterGala
+  "TheInvestigatorsWereDefeatedAtTheMidwinterGala" -> pure TheInvestigatorsWereDefeatedAtTheMidwinterGala
   "YouHaveIdentifiedTheSolution" -> pure YouHaveIdentifiedTheSolution
   "YouHaveTranslatedTheGlyphs" -> pure YouHaveTranslatedTheGlyphs
   "YouHaveIdentifiedTheStone" -> pure YouHaveIdentifiedTheStone


### PR DESCRIPTION
## Summary
- initialize act and agenda decks for the Midwinter Gala scenario
- implement basic resolution flow choosing a guest asset to add

## Testing
- `make test` *(fails: No rule to make target)*
- `stack test` *(fails: command not found)*
- `cabal test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685041c0adb0832d9e1e13a8be492d27