### PR TITLE
Update Rainy London Streets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,21 @@ give concrete steps for the most common types.
 5. Register the card in `Arkham/Act/Cards.hs` and add it to `allActs` in
    `Arkham/Act.hs`.
 
+## Additional implementation guidelines
+
+* Reuse existing helpers whenever possible. For encounter deck logic use
+  `getEncounterDeckKey` along with the `DiscardUntilFirst` message.
+* Use `scenarioI18n` when the scenario provides it to scope translation keys;
+  otherwise wrap i18n helpers in `withI18n`.
+* For horror healing prefer `getHealHorrorMessage` and check
+  `canHaveHorrorHealed`.
+* When effects may apply to other investigators use `affectsOthers`.
+* Only invoke `beginSkillTest` for tests that are not bold. Attach abilities
+  with `withBaseAbilities` or `withRevealedAbilities` as appropriate and avoid
+  using "You" outside of `CardDef` or `Ability` definitions.
+* `backend/.projections.json` includes templates for each card type showing the
+  minimal module structure.
+
 ## Pull Request guidelines
 
 * Keep commits focused and descriptive.

--- a/backend/arkham-api/library/Arkham/Location/Cards/RainyLondonStreets.hs
+++ b/backend/arkham-api/library/Arkham/Location/Cards/RainyLondonStreets.hs
@@ -4,6 +4,7 @@ import Arkham.Ability
 import Arkham.Helpers.Act (getCurrentActStep)
 import Arkham.Helpers.Modifiers
 import Arkham.Location.Cards qualified as Cards
+import Arkham.Location.Helpers (resignAction)
 import Arkham.Location.Import.Lifted
 import Arkham.Matcher
 
@@ -16,9 +17,10 @@ rainyLondonStreets = location RainyLondonStreets Cards.rainyLondonStreets 1 (Per
 
 instance HasAbilities RainyLondonStreets where
   getAbilities (RainyLondonStreets a) =
-    extendRevealed a
+    extendRevealed
+      a
       [ mkAbility a 1 $ forced $ DiscoveringLastClue #after Anyone (be a)
-      , locationResignAction a
+      , withI18nTooltip "rainyLondonStreets.resign" $ resignAction a
       ]
 
 instance HasModifiersFor RainyLondonStreets where

--- a/backend/arkham-api/library/Arkham/Location/Cards/RainyLondonStreets.hs
+++ b/backend/arkham-api/library/Arkham/Location/Cards/RainyLondonStreets.hs
@@ -17,10 +17,9 @@ rainyLondonStreets = location RainyLondonStreets Cards.rainyLondonStreets 1 (Per
 
 instance HasAbilities RainyLondonStreets where
   getAbilities (RainyLondonStreets a) =
-    extendRevealed
-      a
+    extendRevealed a
       [ mkAbility a 1 $ forced $ DiscoveringLastClue #after Anyone (be a)
-      , withI18nTooltip "rainyLondonStreets.resign" $ resignAction a
+      , withI18nTooltip "We should wait for Inspector Flint..." $ resignAction a
       ]
 
 instance HasModifiersFor RainyLondonStreets where


### PR DESCRIPTION
## Summary
- adjust Rainy London Streets resign action to mirror Grand Entryway style

## Testing
- `fourmolu -i backend/arkham-api/library/Arkham/Location/Cards/RainyLondonStreets.hs` *(fails: command not found)*
- `stack test` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551e66d7f0832d8100e214f25578d9