### PR TITLE
Add Big Ben & Westminster Abbey locations

### DIFF
--- a/backend/arkham-api/library/Arkham/Location.hs
+++ b/backend/arkham-api/library/Arkham/Location.hs
@@ -946,4 +946,11 @@ allLocations =
     , SomeLocationCard bedroomTheMidwinterGala
     , SomeLocationCard libraryTheMidwinterGala
     , SomeLocationCard parlorTheMidwinterGala
+    , -- Riddles and Rain
+      SomeLocationCard rainyLondonStreets
+    , SomeLocationCard bigBen
+    , SomeLocationCard westminsterAbbey
+    , SomeLocationCard kensingtonGardens
+    , SomeLocationCard theTowerBridge
+    , SomeLocationCard traitorsGate
     ]

--- a/backend/arkham-api/library/Arkham/Location/Cards.hs
+++ b/backend/arkham-api/library/Arkham/Location/Cards.hs
@@ -163,6 +163,7 @@ allLocationCards =
       , bathroom
       , bedroom
       , bedroomTheMidwinterGala
+      , bigBen
       , billiardsRoom
       , billiardsRoomSpectral
       , bishopsBrook_202
@@ -472,6 +473,7 @@ allLocationCards =
       , joeMazurewiczsRoom
       , kadatheron
       , keziahsRoom
+      , kensingtonGardens
       , kitchen
       , knightsHall
       , laBellaLuna
@@ -801,6 +803,7 @@ allLocationCards =
       , theOnyxCastle
       , theSummit
       , theThroneRoom
+      , theTowerBridge
       , theWhiteShip
       , throneRoom
       , tidalPool
@@ -821,6 +824,7 @@ allLocationCards =
       , trailOfTheDead
       , trainTracks
       , trappersCabin
+      , traitorsGate
       , trapRoom
       , treacherousDescent
       , treacherousPath
@@ -870,6 +874,7 @@ allLocationCards =
       , waterfall
       , wavewornIsland
       , wellOfSouls
+      , westminsterAbbey
       , whateleyRuins_250
       , whateleyRuins_251
       , whiteBluff
@@ -9536,5 +9541,58 @@ rainyLondonStreets =
     [London]
     Equals
     [Circle, Square, Triangle, Squiggle]
+    RiddlesAndRain
+
+bigBen :: CardDef
+bigBen =
+  victory 1
+    $ location
+      "09511"
+      "Big Ben"
+      [London]
+      Triangle
+      [Equals, Circle]
+      RiddlesAndRain
+
+westminsterAbbey :: CardDef
+westminsterAbbey =
+  victory 1
+    $ location
+      "09512"
+      "Westminster Abbey"
+      [London]
+      Circle
+      [Equals, Triangle]
+      RiddlesAndRain
+
+kensingtonGardens :: CardDef
+kensingtonGardens =
+  victory 1
+    $ location
+      "09513"
+      "Kensington Gardens"
+      [London]
+      Square
+      [Equals]
+      RiddlesAndRain
+
+theTowerBridge :: CardDef
+theTowerBridge =
+  location
+    "09514"
+    "The Tower Bridge"
+    [London]
+    Squiggle
+    [Equals, Moon]
+    RiddlesAndRain
+
+traitorsGate :: CardDef
+traitorsGate =
+  location
+    "09515"
+    "Traitors' Gate"
+    [London]
+    T
+    [Squiggle, Moon]
     RiddlesAndRain
 

--- a/backend/arkham-api/library/Arkham/Location/Cards/BigBen.hs
+++ b/backend/arkham-api/library/Arkham/Location/Cards/BigBen.hs
@@ -1,0 +1,37 @@
+module Arkham.Location.Cards.BigBen (bigBen, BigBen(..)) where
+
+import Arkham.Ability
+import Arkham.Location.Cards qualified as Cards
+import Arkham.Location.Import.Lifted
+import Arkham.Scenarios.RiddlesAndRain.Helpers (scenarioI18n)
+
+newtype BigBen = BigBen LocationAttrs
+  deriving anyclass (IsLocation, HasModifiersFor)
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+bigBen :: LocationCard BigBen
+bigBen = location BigBen Cards.bigBen 4 (PerPlayer 1)
+
+instance HasAbilities BigBen where
+  getAbilities (BigBen a) =
+    extendRevealed
+      a
+      [ scenarioI18n
+          $ skillTestAbility
+          $ groupLimit PerTurn
+          $ restricted a 1 Here
+          $ FastAbility Free
+      ]
+
+instance RunMessage BigBen where
+  runMessage msg l@(BigBen attrs) = runQueueT $ case msg of
+    UseThisAbility iid (isSource attrs -> True) 1 -> do
+      sid <- getRandom
+      beginSkillTest sid iid (attrs.ability 1) iid #agility (Fixed 2)
+      pure l
+    FailedThisSkillTest iid (isAbilitySource attrs 1 -> True) -> do
+      assignHorror iid (attrs.ability 1) 1
+      pure l
+    PassedThisSkillTest _ (isAbilitySource attrs 1 -> True) -> do
+      pure l
+    _ -> BigBen <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Location/Cards/KensingtonGardens.hs
+++ b/backend/arkham-api/library/Arkham/Location/Cards/KensingtonGardens.hs
@@ -1,0 +1,24 @@
+module Arkham.Location.Cards.KensingtonGardens (kensingtonGardens, KensingtonGardens(..)) where
+
+import Arkham.Ability
+import Arkham.Location.Cards qualified as Cards
+import Arkham.Location.Import.Lifted
+import Arkham.Scenarios.RiddlesAndRain.Helpers (scenarioI18n)
+
+newtype KensingtonGardens = KensingtonGardens LocationAttrs
+  deriving anyclass (IsLocation, HasModifiersFor)
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+kensingtonGardens :: LocationCard KensingtonGardens
+kensingtonGardens = location KensingtonGardens Cards.kensingtonGardens 2 (PerPlayer 1)
+
+instance HasAbilities KensingtonGardens where
+  getAbilities (KensingtonGardens a) =
+    extendRevealed
+      a
+      [ -- TODO: Expose enemy/decoy abilities not yet implemented
+      ]
+
+instance RunMessage KensingtonGardens where
+  runMessage msg (KensingtonGardens attrs) =
+    KensingtonGardens <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Location/Cards/TheTowerBridge.hs
+++ b/backend/arkham-api/library/Arkham/Location/Cards/TheTowerBridge.hs
@@ -1,0 +1,31 @@
+module Arkham.Location.Cards.TheTowerBridge (theTowerBridge, TheTowerBridge(..)) where
+
+import Arkham.Ability
+import Arkham.Location.Cards qualified as Cards
+import Arkham.Location.Import.Lifted
+import Arkham.Message.Lifted.Choose
+import Arkham.Scenarios.RiddlesAndRain.Helpers (scenarioI18n)
+
+newtype TheTowerBridge = TheTowerBridge LocationAttrs
+  deriving anyclass (IsLocation, HasModifiersFor)
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+theTowerBridge :: LocationCard TheTowerBridge
+theTowerBridge = location TheTowerBridge Cards.theTowerBridge 2 (PerPlayer 1)
+
+instance HasAbilities TheTowerBridge where
+  getAbilities (TheTowerBridge a) =
+    extendRevealed1 a $ skillTestAbility $ restricted a 1 Here actionAbility
+
+instance RunMessage TheTowerBridge where
+  runMessage msg l@(TheTowerBridge attrs) = runQueueT $ case msg of
+    UseThisAbility iid (isSource attrs -> True) 1 -> do
+      sid <- getRandom
+      chooseOneM iid $ do
+        for_ [#willpower, #intellect] \skill ->
+          skillLabeled skill $ beginSkillTest sid iid (attrs.ability 1) iid skill (Fixed 5)
+      pure l
+    PassedThisSkillTest _ (isAbilitySource attrs 1 -> True) -> do
+      push $ PlaceLocationMatching "Traitors' Gate"
+      pure l
+    _ -> TheTowerBridge <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Location/Cards/TraitorsGate.hs
+++ b/backend/arkham-api/library/Arkham/Location/Cards/TraitorsGate.hs
@@ -1,0 +1,34 @@
+module Arkham.Location.Cards.TraitorsGate (traitorsGate, TraitorsGate(..)) where
+
+import Arkham.Ability
+import Arkham.Location.Cards qualified as Cards
+import Arkham.Location.Import.Lifted
+import Arkham.Message.Lifted.Choose
+import Arkham.Scenarios.RiddlesAndRain.Helpers (scenarioI18n)
+
+newtype TraitorsGate = TraitorsGate LocationAttrs
+  deriving anyclass (IsLocation, HasModifiersFor)
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+traitorsGate :: LocationCard TraitorsGate
+traitorsGate = location TraitorsGate Cards.traitorsGate 4 (PerPlayer 1)
+
+instance HasAbilities TraitorsGate where
+  getAbilities (TraitorsGate a) =
+    extendRevealed1 a $ skillTestAbility $ restricted a 1 Here actionAbility
+
+instance RunMessage TraitorsGate where
+  runMessage msg l@(TraitorsGate attrs) = runQueueT $ case msg of
+    UseThisAbility iid (isSource attrs -> True) 1 -> do
+      sid <- getRandom
+      chooseOneM iid $ do
+        for_ [#combat, #agility] \skill ->
+          skillLabeled skill $ beginSkillTest sid iid (attrs.ability 1) iid skill (Fixed 5)
+      pure l
+    PassedThisSkillTest _ (isAbilitySource attrs 1 -> True) -> do
+      -- TODO: reveal the Tower of London
+      pure l
+    FailedThisSkillTest iid (isAbilitySource attrs 1 -> True) -> do
+      assignDamage iid (attrs.ability 1) 1
+      pure l
+    _ -> TraitorsGate <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Location/Cards/WestminsterAbbey.hs
+++ b/backend/arkham-api/library/Arkham/Location/Cards/WestminsterAbbey.hs
@@ -1,0 +1,33 @@
+module Arkham.Location.Cards.WestminsterAbbey (westminsterAbbey, WestminsterAbbey(..)) where
+
+import Arkham.Ability
+import Arkham.Action qualified as Action
+import Arkham.Location.Cards qualified as Cards
+import Arkham.Location.Import.Lifted
+import Arkham.Scenarios.RiddlesAndRain.Helpers (scenarioI18n)
+
+newtype WestminsterAbbey = WestminsterAbbey LocationAttrs
+  deriving anyclass (IsLocation, HasModifiersFor)
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
+
+westminsterAbbey :: LocationCard WestminsterAbbey
+westminsterAbbey = location WestminsterAbbey Cards.westminsterAbbey 1 (PerPlayer 1)
+
+instance HasAbilities WestminsterAbbey where
+  getAbilities (WestminsterAbbey a) =
+    extendRevealed
+      a
+      [ scenarioI18n
+          $ skillTestAbility
+          $ groupLimit PerGame
+          $ restricted a 1 Here
+          $ ActionAbility [Action.Parley] (ActionCost 1)
+      ]
+
+instance RunMessage WestminsterAbbey where
+  runMessage msg l@(WestminsterAbbey attrs) = runQueueT $ case msg of
+    UseThisAbility iid (isSource attrs -> True) 1 -> do
+      sid <- getRandom
+      beginSkillTest sid iid (attrs.ability 1) iid #willpower (Fixed 1)
+      pure l
+    _ -> WestminsterAbbey <$> liftRunMessage msg attrs


### PR DESCRIPTION
## Summary
- add `BigBen` and `WestminsterAbbey` location modules
- register new locations in `Location.hs`
- define card data in `Location/Cards.hs`
- add `KensingtonGardens`, `TheTowerBridge`, and `TraitorsGate` locations

## Testing
- `fourmolu -i arkham-api/library/Arkham/Location/Cards/KensingtonGardens.hs arkham-api/library/Arkham/Location/Cards/TheTowerBridge.hs arkham-api/library/Arkham/Location/Cards/TraitorsGate.hs arkham-api/library/Arkham/Location/Cards/BigBen.hs arkham-api/library/Arkham/Location/Cards/WestminsterAbbey.hs arkham-api/library/Arkham/Location/Cards.hs arkham-api/library/Arkham/Location.hs` *(fails: command not found)*
- `stack test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555de8afa0832d8fe834ae9fce3ca7