### PR TITLE
Add KeyType card type

### DIFF
--- a/backend/arkham-api/library/Api/Arkham/Helpers.hs
+++ b/backend/arkham-api/library/Api/Arkham/Helpers.hs
@@ -186,3 +186,4 @@ displayCardType = \case
   EncounterAssetType -> "asset"
   EncounterEventType -> "event"
   InvestigatorType -> "investigator"
+  KeyType -> "key"

--- a/backend/arkham-api/library/Arkham/Card/CardType.hs
+++ b/backend/arkham-api/library/Arkham/Card/CardType.hs
@@ -16,6 +16,7 @@ data CardType
   | LocationType
   | EncounterAssetType
   | EncounterEventType
+  | KeyType
   | ActType
   | AgendaType
   | StoryType
@@ -36,6 +37,7 @@ encounterCardTypes =
   , StoryType
   , ActType
   , AgendaType
+  , KeyType
   ]
 
 playerCardTypes :: [CardType]

--- a/backend/arkham-api/library/Arkham/Helpers/Source.hs
+++ b/backend/arkham-api/library/Arkham/Helpers/Source.hs
@@ -5,9 +5,9 @@ import Arkham.Classes.HasGame
 import Arkham.Classes.Query
 import Arkham.Field.Import
 import {-# SOURCE #-} Arkham.GameEnv (getCard)
+import Arkham.Helpers.Modifiers
 import Arkham.Helpers.Query
 import Arkham.Helpers.Ref
-import Arkham.Helpers.Modifiers
 import Arkham.Id
 import Arkham.Matcher qualified as Matcher
 import Arkham.Prelude
@@ -291,6 +291,7 @@ sourceMatches s = \case
         c <- getCard cid
         pure $ c.kind == InvestigatorType
       _ -> pure False
+    KeyType -> pure False
     ScenarioType -> case s of
       ScenarioSource -> pure True
       CardIdSource cid -> do

--- a/backend/arkham-api/library/Arkham/Key/Cards.hs
+++ b/backend/arkham-api/library/Arkham/Key/Cards.hs
@@ -1,0 +1,8 @@
+module Arkham.Key.Cards where
+
+import Arkham.Prelude
+
+import Arkham.Card
+
+allKeyCards :: Map CardCode CardDef
+allKeyCards = mempty

--- a/backend/arkham-api/library/Arkham/Key/Import/Lifted.hs
+++ b/backend/arkham-api/library/Arkham/Key/Import/Lifted.hs
@@ -1,0 +1,10 @@
+module Arkham.Key.Import.Lifted (module X, module Arkham.Key.Import.Lifted) where
+
+import Arkham.Classes as X
+import Arkham.Id as X
+import Arkham.Key.Runner as X
+import Arkham.Message as X (Message(..))
+import Arkham.Message.Lifted as X
+import Arkham.Prelude as X
+import Arkham.Source as X
+import Arkham.Target as X

--- a/backend/arkham-api/library/Arkham/Key/Runner.hs
+++ b/backend/arkham-api/library/Arkham/Key/Runner.hs
@@ -1,0 +1,14 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Arkham.Key.Runner (module X) where
+
+import Arkham.Prelude
+
+import Arkham.Classes as X
+import Arkham.Helpers.Message as X
+import Arkham.Id as X
+import Arkham.Key.Types as X
+import Arkham.Source as X
+import Arkham.Target as X
+
+instance RunMessage KeyAttrs where
+  runMessage _ attrs = pure attrs

--- a/backend/arkham-api/library/Arkham/Key/Types.hs
+++ b/backend/arkham-api/library/Arkham/Key/Types.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Arkham.Key.Types where
+
+import Arkham.Prelude
+
+import Arkham.Classes
+import Arkham.Classes.RunMessage.Internal
+import Arkham.Id
+import Arkham.Json
+import Arkham.Key
+import Arkham.Name
+import Arkham.Projection
+
+-- | Whether a key is stable or unstable
+data KeyStability = Stable | Unstable
+  deriving stock (Show, Eq, Generic, Data)
+  deriving anyclass (ToJSON, FromJSON)
+
+data KeyAttrs = KeyAttrs
+  { keyArkhamKey :: ArkhamKey
+  , keyBearer :: Maybe InvestigatorId
+  , keyStability :: KeyStability
+  , keyMeta :: Value
+  }
+  deriving stock (Show, Eq)
+
+makeLensesWith suffixedFields ''KeyAttrs
+
+class
+  ( Typeable a
+  , ToJSON a
+  , FromJSON a
+  , Eq a
+  , Show a
+  , HasAbilities a
+  , HasModifiersFor a
+  , RunMessage a
+  , Entity a
+  , EntityId a ~ ArkhamKey
+  , EntityAttrs a ~ KeyAttrs
+  , RunType a ~ a
+  ) =>
+  IsKeyCard a
+
+type KeyCard a = CardBuilder ArkhamKey a

--- a/backend/arkham-api/library/Arkham/Matcher.hs
+++ b/backend/arkham-api/library/Arkham/Matcher.hs
@@ -484,6 +484,7 @@ instance Has InvestigatorMatcher CardDef where
     LocationType -> error "invalid matcher"
     EncounterAssetType -> HasMatchingAsset (assetIs cardDef)
     EncounterEventType -> HasMatchingEvent (eventIs cardDef)
+    KeyType -> error "invalid matcher"
     ActType -> error "invalid matcher"
     AgendaType -> error "invalid matcher"
     StoryType -> error "invalid matcher"
@@ -501,6 +502,7 @@ instance Exists CardDef where
     LocationType -> exists $ locationIs def
     EncounterAssetType -> exists $ assetIs def
     EncounterEventType -> exists $ eventIs def
+    KeyType -> error "Not implemented"
     ActType -> error "Not implemented"
     AgendaType -> error "Not implemented"
     StoryType -> exists $ storyIs def


### PR DESCRIPTION
## Summary
- add `KeyType` constructor to `CardType`
- recognize `KeyType` in encounter card types
- display Key type strings
- handle `KeyType` in pattern matches
- update source matching helper

## Testing
- `fourmolu -i backend/arkham-api/library/Arkham/Card/CardType.hs`
- `fourmolu -i backend/arkham-api/library/Api/Arkham/Helpers.hs`
- `fourmolu -i backend/arkham-api/library/Arkham/Matcher.hs`
- `fourmolu -i backend/arkham-api/library/Arkham/Helpers/Source.hs`
- `stack test` *(fails: `stack` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685572a45efc832db10f7dec1296d6f6