### PR TITLE
Add Key card framework

### DIFF
--- a/backend/arkham-api/library/Arkham/Key/Cards.hs
+++ b/backend/arkham-api/library/Arkham/Key/Cards.hs
@@ -1,0 +1,8 @@
+module Arkham.Key.Cards where
+
+import Arkham.Prelude
+
+import Arkham.Card
+
+allKeyCards :: Map CardCode CardDef
+allKeyCards = mempty

--- a/backend/arkham-api/library/Arkham/Key/Import/Lifted.hs
+++ b/backend/arkham-api/library/Arkham/Key/Import/Lifted.hs
@@ -1,0 +1,10 @@
+module Arkham.Key.Import.Lifted (module X, module Arkham.Key.Import.Lifted) where
+
+import Arkham.Classes as X
+import Arkham.Id as X
+import Arkham.Key.Runner as X
+import Arkham.Message as X (Message(..))
+import Arkham.Message.Lifted as X
+import Arkham.Prelude as X
+import Arkham.Source as X
+import Arkham.Target as X

--- a/backend/arkham-api/library/Arkham/Key/Runner.hs
+++ b/backend/arkham-api/library/Arkham/Key/Runner.hs
@@ -1,0 +1,14 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Arkham.Key.Runner (module X) where
+
+import Arkham.Prelude
+
+import Arkham.Classes as X
+import Arkham.Helpers.Message as X
+import Arkham.Id as X
+import Arkham.Key.Types as X
+import Arkham.Source as X
+import Arkham.Target as X
+
+instance RunMessage KeyAttrs where
+  runMessage _ attrs = pure attrs

--- a/backend/arkham-api/library/Arkham/Key/Types.hs
+++ b/backend/arkham-api/library/Arkham/Key/Types.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Arkham.Key.Types where
+
+import Arkham.Prelude
+
+import Arkham.Classes
+import Arkham.Classes.RunMessage.Internal
+import Arkham.Id
+import Arkham.Json
+import Arkham.Key
+import Arkham.Name
+import Arkham.Projection
+
+-- | Whether a key is stable or unstable
+data KeyStability = Stable | Unstable
+  deriving stock (Show, Eq, Generic, Data)
+  deriving anyclass (ToJSON, FromJSON)
+
+data KeyAttrs = KeyAttrs
+  { keyArkhamKey :: ArkhamKey
+  , keyBearer :: Maybe InvestigatorId
+  , keyStability :: KeyStability
+  , keyMeta :: Value
+  }
+  deriving stock (Show, Eq)
+
+makeLensesWith suffixedFields ''KeyAttrs
+
+class
+  ( Typeable a
+  , ToJSON a
+  , FromJSON a
+  , Eq a
+  , Show a
+  , HasAbilities a
+  , HasModifiersFor a
+  , RunMessage a
+  , Entity a
+  , EntityId a ~ ArkhamKey
+  , EntityAttrs a ~ KeyAttrs
+  , RunType a ~ a
+  ) =>
+  IsKeyCard a
+
+type KeyCard a = CardBuilder ArkhamKey a


### PR DESCRIPTION
## Summary
- add Arkham.Key modules for key cards
- define `KeyAttrs` with bearer and stability
- export key utilities in a new lifted module
- provide a stub key card registry

## Testing
- `fourmolu -i backend/arkham-api/library/Arkham/Key/Types.hs` *(fails: command not found)*
- `stack test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685585f39c24832da73ea03370408e95