### PR TITLE
Fix Midwinter Gala asset on enemy defeat

### DIFF
--- a/backend/arkham-api/library/Arkham/Asset/Assets/ThePaleLanternBeguilingAura.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ThePaleLanternBeguilingAura.hs
@@ -26,6 +26,7 @@ instance HasAbilities ThePaleLanternBeguilingAura where
         $ restricted a 2 ControlsThis
         $ actionAbilityWithCost (exhaust a)
     , mkAbility a 3 $ forced $ AssetLeavesPlay #when (be a)
+    , mkAbility a 4 $ forced $ EnemyLeavesPlay #when $ EnemyWithAttachedAsset (be a)
     ]
 
 instance RunMessage ThePaleLanternBeguilingAura where
@@ -42,6 +43,11 @@ instance RunMessage ThePaleLanternBeguilingAura where
       lid <- fieldJust AssetLocation attrs.id
       flipOverBy iid (attrs.ability 1) attrs
       place attrs.id $ AttachedToLocation lid
+      pure a
+    UseThisAbility _ (isSource attrs -> True) 4 -> do
+      case attrs.placement of
+        AttachedToEnemy enemyId -> withLocationOf enemyId \lid -> place attrs.id (AttachedToLocation lid)
+        _ -> pure ()
       pure a
     PassedThisSkillTest iid (isAbilitySource attrs 3 -> True) -> do
       placeTokens (attrs.ability 3) attrs #damage 1

--- a/backend/arkham-api/library/Arkham/Asset/Assets/ThePaleLanternHypnoticGlow.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ThePaleLanternHypnoticGlow.hs
@@ -21,6 +21,7 @@ instance HasAbilities ThePaleLanternHypnoticGlow where
   getAbilities (ThePaleLanternHypnoticGlow a) =
     [ mkAbility a 1 $ forced $ AssetLeavesPlay #when (be a)
     , restricted a 2 (OnSameLocation <> additionalCriteria) actionAbility
+    , mkAbility a 3 $ forced $ EnemyLeavesPlay #when $ EnemyWithAttachedAsset (be a)
     ]
    where
     additionalCriteria =
@@ -47,6 +48,11 @@ instance RunMessage ThePaleLanternHypnoticGlow where
       chooseOneM iid do
         for_ [#combat, #agility] \kind ->
           skillLabeled kind $ beginSkillTest sid iid (attrs.ability 2) iid kind (Fixed 1)
+      pure a
+    UseThisAbility _ (isSource attrs -> True) 3 -> do
+      case attrs.placement of
+        AttachedToEnemy enemyId -> withLocationOf enemyId \lid -> place attrs.id (AttachedToLocation lid)
+        _ -> pure ()
       pure a
     PassedThisSkillTest iid (isAbilitySource attrs 2 -> True) -> do
       takeControlOfAsset iid attrs


### PR DESCRIPTION
## Summary
- handle The Pale Lantern assets when their attached enemy leaves play

## Testing
- `stack test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855aebb2c20832da1e5024227dbbf40